### PR TITLE
fixed action btn

### DIFF
--- a/js/buttons.js
+++ b/js/buttons.js
@@ -23,6 +23,7 @@
       openFABMenu($this);
     },
     closeFAB: function() {
+       var $this = $(this);
       closeFABMenu($this);
     }
   });
@@ -34,12 +35,14 @@
       $this.addClass('active');
       $this.find('ul .btn-floating').velocity(
         { scaleY: ".4", scaleX: ".4", translateY: "40px"},
+        { display: "none" },
         { duration: 0 });
 
       var time = 0;
       $this.find('ul .btn-floating').reverse().each(function () {
         $(this).velocity(
           { opacity: "1", scaleX: "1", scaleY: "1", translateY: "0"},
+          { display: "block" },
           { duration: 80, delay: time });
         time += 40;
       });
@@ -53,6 +56,7 @@
     $this.find('ul .btn-floating').velocity("stop", true);
     $this.find('ul .btn-floating').velocity(
       { opacity: "0", scaleX: ".4", scaleY: ".4", translateY: "40px"},
+      { display: "none" },
       { duration: 80 }
     );
   };


### PR DESCRIPTION
- the Buttons  is clickable if only 

```
   opacity: "0" 
```
- this is a screenshot from chrome dev tools 
  you will notice i can select and click 
  ![image](https://cloud.githubusercontent.com/assets/11564172/10127178/c4e7542c-65ae-11e5-9dff-51197d0218c7.png)
-  add 

```
 display: "none" 
```

 to the animation  , it will make the list items un-clickable 
- add

```
var $this = $(this);
```

to closeFAB function so i can call the 

```
    $('.fixed-action-btn').closeFAB();
```

 to add

```
display: "none"   
```

 when first time page loaded 

```
  $(document).ready(function(){
      $('.fixed-action-btn').closeFAB();
   });
```

thanks @@
